### PR TITLE
added notebook on filtering test set based on seq length

### DIFF
--- a/ml/filtered_sol_test.ipynb
+++ b/ml/filtered_sol_test.ipynb
@@ -198,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "c3844dc3",
+   "id": "66de179c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "0ccb7f1e",
+   "id": "c84adb73",
    "metadata": {},
    "outputs": [
     {
@@ -261,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "efa06b44",
+   "id": "02699a12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "4465c389",
+   "id": "6df2204b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +288,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "122ecea5",
+   "id": "36c4d71b",
    "metadata": {},
    "source": [
     "## No length filter "
@@ -296,15 +296,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "8824b2c2",
+   "execution_count": 20,
+   "id": "21941196",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "116/116 [==============================] - 8s 32ms/step - loss: 0.5770 - auc_1: 0.7561 - binary_accuracy: 0.7100\n"
+      "116/116 [==============================] - 4s 32ms/step - loss: 0.5770 - auc_1: 0.7561 - binary_accuracy: 0.7100\n"
      ]
     },
     {
@@ -313,7 +313,7 @@
        "[0.5769950747489929, 0.7561261057853699, 0.7100270986557007]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -327,8 +327,45 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "91c30df4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([ 12.,  18.,  59., 128., 185., 263., 270., 337., 279., 294.]),\n",
+       " array([ 20. ,  37.8,  55.6,  73.4,  91.2, 109. , 126.8, 144.6, 162.4,\n",
+       "        180.2, 198. ]),\n",
+       " <BarContainer object of 10 artists>)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD6CAYAAABamQdMAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAARz0lEQVR4nO3df4xl9Xnf8fenCyGR7QYI09V2d9sh7qYRqZQFTSlVnMg1TQykzeKmRaAq3rpIm0hYstX0xzqWGkcqkt3WRrKUEq0F8TpyjGlsi1UgjQlBtfwHkIGsl10wZWwvYlfL7sQ/sC23tOCnf9zvJneHmb3z686d/fr9kq7uOc85555nztz9zJnvnHM3VYUkqS9/bdINSJLWn+EuSR0y3CWpQ4a7JHXIcJekDhnuktShkeGe5IeTPJHkS0mOJfmtVv94kq8lOdweu1s9ST6aZC7JkSTXjPlrkCQtcNEy1nkFeFtVfTfJxcAXk/xRW/bvquoPFqx/I7CrPf4BcHd7XtIVV1xR09PTK2pckn7QPfnkk39RVVOLLRsZ7jW4y+m7bfbi9jjfnU97gE+07R5LcmmSbVV1aqkNpqenmZ2dHdWKJGlIkheWWrasMfckW5IcBs4AD1fV423RnW3o5a4kl7TaduDFoc1PtJokaYMsK9yr6rWq2g3sAK5N8veA9wE/Cfx94HLgP6xkx0n2JZlNMjs/P7+yriVJ57Wiq2Wq6lvAo8ANVXWqBl4Bfhe4tq12Etg5tNmOVlv4WgeqaqaqZqamFh0ykiSt0nKulplKcmmb/hHg54EvJ9nWagFuBo62TQ4B72xXzVwHvHy+8XZJ0vpbztUy24CDSbYw+GFwf1X9YZI/TTIFBDgM/Fpb/yHgJmAO+B7wrnXvWpJ0Xsu5WuYIcPUi9bctsX4Bd6y9NUnSanmHqiR1yHCXpA4Z7pLUoeX8QVXSD5Dp/Q9ObN/HP/iLE9t3bzxzl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUoZHhnuSHkzyR5EtJjiX5rVa/MsnjSeaSfDrJD7X6JW1+ri2fHvPXIElaYDln7q8Ab6uqnwZ2AzckuQ74EHBXVf0d4JvA7W3924FvtvpdbT1J0gYaGe418N02e3F7FPA24A9a/SBwc5ve0+Zpy69PkvVqWJI02rLG3JNsSXIYOAM8DHwF+FZVvdpWOQFsb9PbgRcB2vKXgR9b5DX3JZlNMjs/P7+mL0KSdK5lhXtVvVZVu4EdwLXAT651x1V1oKpmqmpmampqrS8nSRqyoqtlqupbwKPAPwQuTXJRW7QDONmmTwI7AdryHwW+vh7NSpKWZzlXy0wlubRN/wjw88CzDEL+n7fV9gIPtOlDbZ62/E+rqtaxZ0nSCBeNXoVtwMEkWxj8MLi/qv4wyTPAfUn+E/DnwD1t/XuA30syB3wDuHUMfUvSupne/+DE9n38g784ltcdGe5VdQS4epH6VxmMvy+s/x/gX6xLd5KkVfEOVUnqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktQhw12SOrScm5gkaUNM8mai3njmLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIa+WkTYprxzRWnjmLkkdMtwlqUOGuyR1yDF3aQTHvnUh8sxdkjpkuEtShwx3SeqQ4S5JHRoZ7kl2Jnk0yTNJjiV5T6t/IMnJJIfb46ahbd6XZC7Jc0nePs4vQJL0esu5WuZV4Ner6qkkbwKeTPJwW3ZXVf3X4ZWTXAXcCvwU8DeBP0nyE1X12no2Lkla2sgz96o6VVVPtenvAM8C28+zyR7gvqp6paq+BswB165Hs5Kk5VnRmHuSaeBq4PFWeneSI0nuTXJZq20HXhza7ASL/DBIsi/JbJLZ+fn5lXcuSVrSssM9yRuBzwDvrapvA3cDbwZ2A6eAD69kx1V1oKpmqmpmampqJZtKkkZYVrgnuZhBsH+yqj4LUFWnq+q1qvo+8DH+aujlJLBzaPMdrSZJ2iDLuVomwD3As1X1kaH6tqHV3gEcbdOHgFuTXJLkSmAX8MT6tSxJGmU5V8v8DPArwNNJDrfabwC3JdkNFHAc+FWAqjqW5H7gGQZX2tzhlTKStLFGhntVfRHIIoseOs82dwJ3rqEvSdIaeIeqJHXIcJekDhnuktQhw12SOmS4S1KHDHdJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUodGhnuSnUkeTfJMkmNJ3tPqlyd5OMnz7fmyVk+SjyaZS3IkyTXj/iIkSedazpn7q8CvV9VVwHXAHUmuAvYDj1TVLuCRNg9wI7CrPfYBd69715Kk8xoZ7lV1qqqeatPfAZ4FtgN7gINttYPAzW16D/CJGngMuDTJtvVuXJK0tBWNuSeZBq4GHge2VtWptuglYGub3g68OLTZiVaTJG2QZYd7kjcCnwHeW1XfHl5WVQXUSnacZF+S2SSz8/PzK9lUkjTCssI9ycUMgv2TVfXZVj59drilPZ9p9ZPAzqHNd7TaOarqQFXNVNXM1NTUavuXJC1iOVfLBLgHeLaqPjK06BCwt03vBR4Yqr+zXTVzHfDy0PCNJGkDXLSMdX4G+BXg6SSHW+03gA8C9ye5HXgBuKUtewi4CZgDvge8az0bliSNNjLcq+qLQJZYfP0i6xdwxxr7kiStgXeoSlKHDHdJ6pDhLkkdMtwlqUPLuVpGmrjp/Q9OugXpguKZuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHVoZLgnuTfJmSRHh2ofSHIyyeH2uGlo2fuSzCV5Lsnbx9W4JGlpyzlz/zhwwyL1u6pqd3s8BJDkKuBW4KfaNv8tyZb1alaStDwjw72qvgB8Y5mvtwe4r6peqaqvAXPAtWvoT5K0CmsZc393kiNt2OayVtsOvDi0zolWkyRtoNWG+93Am4HdwCngwyt9gST7kswmmZ2fn19lG5Kkxawq3KvqdFW9VlXfBz7GXw29nAR2Dq26o9UWe40DVTVTVTNTU1OraUOStIRVhXuSbUOz7wDOXklzCLg1ySVJrgR2AU+srUVJ0kpdNGqFJJ8C3gpckeQE8JvAW5PsBgo4DvwqQFUdS3I/8AzwKnBHVb02ls4lSUsaGe5Vddsi5XvOs/6dwJ1raUqStDbeoSpJHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nq0MibmKRh0/sfnHQLkpbBM3dJ6pDhLkkdMtwlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOjQz3JPcmOZPk6FDt8iQPJ3m+PV/W6kny0SRzSY4kuWaczUuSFrecM/ePAzcsqO0HHqmqXcAjbR7gRmBXe+wD7l6fNiVJKzEy3KvqC8A3FpT3AAfb9EHg5qH6J2rgMeDSJNvWqVdJ0jKtdsx9a1WdatMvAVvb9HbgxaH1TrTa6yTZl2Q2yez8/Pwq25AkLWbNf1CtqgJqFdsdqKqZqpqZmppaaxuSpCGrDffTZ4db2vOZVj8J7Bxab0erSZI20GrD/RCwt03vBR4Yqr+zXTVzHfDy0PCNJGmDjPwPspN8CngrcEWSE8BvAh8E7k9yO/ACcEtb/SHgJmAO+B7wrjH0LEkaYWS4V9VtSyy6fpF1C7hjrU1JktbGO1QlqUOGuyR1yHCXpA4Z7pLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDhnuktShkf9Btjaf6f0PTroFSZucZ+6S1KE1nbknOQ58B3gNeLWqZpJcDnwamAaOA7dU1TfX1qYkaSXW48z9H1XV7qqaafP7gUeqahfwSJuXJG2gcQzL7AEOtumDwM1j2Ick6TzWGu4FfD7Jk0n2tdrWqjrVpl8Cti62YZJ9SWaTzM7Pz6+xDUnSsLVeLfOWqjqZ5G8ADyf58vDCqqoktdiGVXUAOAAwMzOz6DqSpNVZ05l7VZ1sz2eAzwHXAqeTbANoz2fW2qQkaWVWHe5J3pDkTWengV8AjgKHgL1ttb3AA2ttUpK0MmsZltkKfC7J2df5/ar6H0n+DLg/ye3AC8Ata29TkrQSqw73qvoq8NOL1L8OXL+WpiRJa+MdqpLUIcNdkjpkuEtShwx3SeqQ4S5JHTLcJalDhrskdchwl6QOGe6S1CHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ2v9b/Z+oE3vf3DSLUjSojxzl6QOGe6S1KELfljGoRFJej3P3CWpQ4a7JHXIcJekDo0t3JPckOS5JHNJ9o9rP5Kk1xtLuCfZAvw2cCNwFXBbkqvGsS9J0uuN68z9WmCuqr5aVf8XuA/YM6Z9SZIWGFe4bwdeHJo/0WqSpA0wsevck+wD9rXZ7yZ5boy7uwL4izG+/nq6UHq9UPoEex2XC6XXTd1nPnTO7Ep7/dtLLRhXuJ8Edg7N72i1v1RVB4ADY9r/OZLMVtXMRuxrrS6UXi+UPsFex+VC6fVC6RPWt9dxDcv8GbAryZVJfgi4FTg0pn1JkhYYy5l7Vb2a5N3AHwNbgHur6tg49iVJer2xjblX1UPAQ+N6/RXakOGfdXKh9Hqh9An2Oi4XSq8XSp+wjr2mqtbrtSRJm4QfPyBJHeoq3JPsTPJokmeSHEvynlb/QJKTSQ63x02T7hUgyfEkT7eeZlvt8iQPJ3m+PV+2Cfr8u0PH7nCSbyd572Y5rknuTXImydGh2qLHMQMfbR+LcSTJNZug1/+S5Mutn88lubTVp5P876Hj+zsT7nPJ73eS97Vj+lySt29Un+fp9dNDfR5PcrjVJ3ZM2/6Xyqj1f79WVTcPYBtwTZt+E/C/GHz8wQeAfzvp/hbp9zhwxYLafwb2t+n9wIcm3eeC/rYALzG4vnZTHFfg54BrgKOjjiNwE/BHQIDrgMc3Qa+/AFzUpj801Ov08HqboM9Fv9/t39iXgEuAK4GvAFsm2euC5R8G/uOkj2nb/1IZte7v167O3KvqVFU91aa/AzzLhXdn7B7gYJs+CNw8uVYWdT3wlap6YdKNnFVVXwC+saC81HHcA3yiBh4DLk2ybUMaZfFeq+rzVfVqm32MwX0hE7XEMV3KHuC+qnqlqr4GzDH4CJINcb5ekwS4BfjURvVzPufJqHV/v3YV7sOSTANXA4+30rvbrzX3boahjqaAzyd5st2xC7C1qk616ZeArZNpbUm3cu4/lM14XGHp47jZPxrjXzM4UzvryiR/nuR/JvnZSTU1ZLHv92Y+pj8LnK6q54dqm+KYLsiodX+/dhnuSd4IfAZ4b1V9G7gbeDOwGzjF4Ne0zeAtVXUNg0/PvCPJzw0vrMHvZZvmcqYMbkj7JeC/t9JmPa7n2GzHcSlJ3g+8CnyylU4Bf6uqrgb+DfD7Sf76pPrjAvl+L3Ab556MbIpjukhG/aX1er92F+5JLmZw0D5ZVZ8FqKrTVfVaVX0f+Bgb+Cvj+VTVyfZ8Bvgcg75On/21qz2fmVyHr3Mj8FRVnYbNe1ybpY7jyI/GmIQk/wr4J8C/bP+4acMcX2/TTzIYy/6JSfV4nu/3Zj2mFwH/DPj02dpmOKaLZRRjeL92Fe5tfO0e4Nmq+shQfXiM6h3A0YXbbrQkb0jyprPTDP6odpTBxzTsbavtBR6YTIeLOucsaDMe1yFLHcdDwDvbVQjXAS8P/To8EUluAP498EtV9b2h+lQG/zcCSX4c2AV8dTJdnvf7fQi4NcklSa5k0OcTG93fIv4x8OWqOnG2MOljulRGMY7366T+ajyOB/AWBr/OHAEOt8dNwO8BT7f6IWDbJuj1xxlcYfAl4Bjw/lb/MeAR4HngT4DLJ91r6+sNwNeBHx2qbYrjyuAHzing/zEYk7x9qePI4KqD32ZwxvY0MLMJep1jMK569j37O23dX27vjcPAU8A/nXCfS36/gfe3Y/occOOkj2mrfxz4tQXrTuyYtv0vlVHr/n71DlVJ6lBXwzKSpAHDXZI6ZLhLUocMd0nqkOEuSR0y3CWpQ4a7JHXIcJekDv1/oc4fjA08lQwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "test_lengths = np.count_nonzero(X_test_f, axis=1)\n",
+    "plt.hist(test_lengths)"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "0431419a",
+   "id": "75ab4c87",
    "metadata": {},
    "source": [
     "## Length filter 1 - 50"
@@ -337,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "2793fba1",
+   "id": "fd3e6abc",
    "metadata": {},
    "outputs": [
     {
@@ -368,7 +405,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "391c8029",
+   "id": "93ed3018",
    "metadata": {},
    "source": [
     "## Length filter 50 - 100"
@@ -377,7 +414,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "775aaec1",
+   "id": "72d3671e",
    "metadata": {},
    "outputs": [
     {
@@ -408,7 +445,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f6fc1c8",
+   "id": "50e31f2f",
    "metadata": {},
    "source": [
     "## Length filter 100 - 150"
@@ -417,7 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "555b49bf",
+   "id": "6aaa08b6",
    "metadata": {},
    "outputs": [
     {
@@ -448,7 +485,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3b4a4e1",
+   "id": "f9bc14c8",
    "metadata": {},
    "source": [
     "## Length filter 150 - 200"
@@ -457,7 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "94c7bf81",
+   "id": "77afc374",
    "metadata": {},
    "outputs": [
     {
@@ -488,7 +525,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7970bf68",
+   "id": "fe877a76",
    "metadata": {},
    "source": [
     "## Length filter 1 - 100"

--- a/ml/filtered_sol_test.ipynb
+++ b/ml/filtered_sol_test.ipynb
@@ -1,0 +1,551 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bf939483",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-12-16 00:19:24.553928: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2022-12-16 00:19:24.745320: E tensorflow/stream_executor/cuda/cuda_blas.cc:2981] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+      "2022-12-16 00:19:25.489540: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /software/gmp/6.2.1/b1/lib:/software/glpk/4.65/lib:/software/zmq/4.2.3/b1/lib:/software/git/2.30.1/lib64:/software/gcc/7.3.0/lib64:/software/gcc/7.3.0/lib:/software/openmpi/4.0.4/b1/lib:/software/cuda/11.4/usr/local/cuda-11.4/lib64:/software/cuda/11.4/usr/local/cuda-11.4/targets/x86_64-linux/lib:/software/cudnn/11.4-8.2.4.15/lib64:/software/slurm/current/lib64:/software/slurm/current/lib\n",
+      "2022-12-16 00:19:25.489853: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /software/gmp/6.2.1/b1/lib:/software/glpk/4.65/lib:/software/zmq/4.2.3/b1/lib:/software/git/2.30.1/lib64:/software/gcc/7.3.0/lib64:/software/gcc/7.3.0/lib:/software/openmpi/4.0.4/b1/lib:/software/cuda/11.4/usr/local/cuda-11.4/lib64:/software/cuda/11.4/usr/local/cuda-11.4/targets/x86_64-linux/lib:/software/cudnn/11.4-8.2.4.15/lib64:/software/slurm/current/lib64:/software/slurm/current/lib\n",
+      "2022-12-16 00:19:25.489866: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import os\n",
+    "import tensorflow as tf\n",
+    "import urllib\n",
+    "import tensorflowjs as tfjs\n",
+    "import json\n",
+    "import keras\n",
+    "from dataclasses import dataclass\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b63ee0fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Num GPUs Available:  4\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Num GPUs Available: \", len(tf.config.list_physical_devices('GPU')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66cc4cfe",
+   "metadata": {},
+   "source": [
+    "## Downloading solubility model from GitHub"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "74b6ac83",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-12-16 00:19:33.512034: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
+      "2022-12-16 00:19:35.640366: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1616] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 10786 MB memory:  -> device: 0, name: Tesla K80, pci bus id: 0000:08:00.0, compute capability: 3.7\n",
+      "2022-12-16 00:19:35.641647: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1616] Created device /job:localhost/replica:0/task:0/device:GPU:1 with 10786 MB memory:  -> device: 1, name: Tesla K80, pci bus id: 0000:09:00.0, compute capability: 3.7\n",
+      "2022-12-16 00:19:35.643294: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1616] Created device /job:localhost/replica:0/task:0/device:GPU:2 with 10786 MB memory:  -> device: 2, name: Tesla K80, pci bus id: 0000:88:00.0, compute capability: 3.7\n",
+      "2022-12-16 00:19:35.644429: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1616] Created device /job:localhost/replica:0/task:0/device:GPU:3 with 10786 MB memory:  -> device: 3, name: Tesla K80, pci bus id: 0000:89:00.0, compute capability: 3.7\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded model from disk.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load json and create model\n",
+    "json_file = open('model_weights_seeded_SOL.json', 'r')\n",
+    "loaded_model_json = json_file.read()\n",
+    "json_file.close()\n",
+    "model = keras.models.model_from_json(loaded_model_json)\n",
+    "# load weights into new model\n",
+    "model.load_weights(\"model_weights_seeded_SOL.h5\")\n",
+    "print(\"Loaded model from disk.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddea335a",
+   "metadata": {},
+   "source": [
+    "# Getting test data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fec1c7d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urllib.request.urlretrieve(\n",
+    "    \"https://github.com/ur-whitelab/peptide-dashboard/raw/master/ml/data/insoluble.npz\",\n",
+    "    \"insoluble.npz\",\n",
+    ")\n",
+    "urllib.request.urlretrieve(\n",
+    "    \"https://github.com/ur-whitelab/peptide-dashboard/raw/master/ml/data/soluble.npz\",\n",
+    "    \"soluble.npz\",\n",
+    ")\n",
+    "with np.load(\"soluble.npz\") as r:\n",
+    "    pos_data = r['arr_0']\n",
+    "with np.load(\"insoluble.npz\") as r:\n",
+    "    neg_data = r['arr_0']\n",
+    "\n",
+    "def counts_aa(vec):\n",
+    "    counts =  tf.histogram_fixed_width(vec, [0, 20], nbins=21)[1:]\n",
+    "    return counts /tf.reduce_sum(counts)\n",
+    "labels = np.concatenate(\n",
+    "    (\n",
+    "        np.ones((pos_data.shape[0], 1), dtype=pos_data.dtype),\n",
+    "        np.zeros((neg_data.shape[0], 1), dtype=pos_data.dtype),\n",
+    "    ),\n",
+    "    axis=0,\n",
+    ")\n",
+    "features = np.concatenate((pos_data, neg_data), axis=0)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2d02de3e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "@dataclass\n",
+    "class Config:\n",
+    "    vocab_size: int\n",
+    "    example_number: int\n",
+    "    batch_size: int\n",
+    "    buffer_size: int\n",
+    "    rnn_units: int\n",
+    "    hidden_dim: int\n",
+    "    embedding_dim: int\n",
+    "    reg_strength: float\n",
+    "    lr: float\n",
+    "    drop_rate: float\n",
+    "        \n",
+    "config = Config(vocab_size=21, # include gap\n",
+    "                example_number=len(labels), \n",
+    "                batch_size=16, \n",
+    "                buffer_size=10000,\n",
+    "                rnn_units=64,\n",
+    "                hidden_dim=64,\n",
+    "                embedding_dim=32,\n",
+    "                reg_strength=0.01,\n",
+    "                lr=1e-4,\n",
+    "                drop_rate=0.2\n",
+    "               )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d89a5026",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we now need to shuffle before creating TF dataset\n",
+    "# so that our train/test/val splits are random\n",
+    "np.random.seed(0) # Note: seed 0 is used for training. DO NOT CHANGE!\n",
+    "                                 \n",
+    "i = np.arange(len(labels))\n",
+    "np.random.shuffle(i)\n",
+    "shuffled_labels = labels[i]\n",
+    "shuffled_features = features[i]\n",
+    "data = tf.data.Dataset.from_tensor_slices((shuffled_features, shuffled_labels)).map(lambda x,y: ((x, counts_aa(x)), y))\n",
+    "# now split into val, test, train and batch\n",
+    "N = len(data)  \n",
+    "L = None#features[0].shape[-1]\n",
+    "split = int(0.1 * N)\n",
+    "test_data = data.take(split).batch(config.batch_size)\n",
+    "nontest = data.skip(split)\n",
+    "val_data, train_data = nontest.take(split).batch(config.batch_size), \\\n",
+    "    nontest.skip(split).shuffle(config.buffer_size).batch(config.batch_size).prefetch(tf.data.experimental.AUTOTUNE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c3844dc3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_test = shuffled_features[:split]\n",
+    "y_test = shuffled_labels[:split]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ef147987",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "use_tpu = False\n",
+    "decay_epochs = 50\n",
+    "decay_steps = N  // config.batch_size * decay_epochs\n",
+    "lr_decayed_fn = tf.keras.optimizers.schedules.CosineDecay(\n",
+    "  config.lr, decay_steps, alpha=1e-3)\n",
+    "opt = tf.optimizers.Adam(lr_decayed_fn)\n",
+    "model.compile(\n",
+    "  opt,\n",
+    "  loss=tf.keras.losses.BinaryCrossentropy(from_logits=False),\n",
+    "  steps_per_execution = 60 if use_tpu else None,\n",
+    "  metrics=[tf.keras.metrics.AUC(from_logits=False), tf.keras.metrics.BinaryAccuracy(threshold=0)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0ccb7f1e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "116/116 [==============================] - 3s 27ms/step\n",
+      "Best Threshold=0.516320, G-Mean=0.697\n",
+      "Accuracy: 0.710\n"
+     ]
+    }
+   ],
+   "source": [
+    "y_hat_test = model.predict(test_data)\n",
+    "from sklearn.metrics import roc_curve\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "fpr, tpr, thresholds = roc_curve(y_test, y_hat_test, drop_intermediate=False)\n",
+    "# calculate the g-mean for each threshold\n",
+    "gmeans = np.sqrt(tpr * (1-fpr))\n",
+    "# locate the index of the largest g-mean\n",
+    "ix = np.argmax(gmeans)\n",
+    "best_accuracy_threshold = thresholds[ix]\n",
+    "print('Best Threshold=%f, G-Mean=%.3f' % (thresholds[ix], gmeans[ix]))\n",
+    "adjusted_y_hat_test = [1 if m>best_accuracy_threshold else 0 for m in y_hat_test]\n",
+    "acc = accuracy_score(y_test, adjusted_y_hat_test, normalize=True)\n",
+    "print(f'Accuracy: {acc:.3f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "efa06b44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compiling the model again based on adjusted decision boundary threshold\n",
+    "model.compile(\n",
+    "  opt,\n",
+    "  loss=tf.keras.losses.BinaryCrossentropy(from_logits=False),\n",
+    "  steps_per_execution = 60 if use_tpu else None,\n",
+    "  metrics=[tf.keras.metrics.AUC(from_logits=False), tf.keras.metrics.BinaryAccuracy(threshold=best_accuracy_threshold)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "4465c389",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def filter_lengths(X,y, min_length=10, max_length=80):\n",
+    "    test_lengths = np.count_nonzero(X, axis=1)\n",
+    "    filtered_idx = np.where((test_lengths>min_length) & (test_lengths<max_length))\n",
+    "    return X[filtered_idx], y[filtered_idx]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "122ecea5",
+   "metadata": {},
+   "source": [
+    "## No length filter "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8824b2c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "116/116 [==============================] - 8s 32ms/step - loss: 0.5770 - auc_1: 0.7561 - binary_accuracy: 0.7100\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[0.5769950747489929, 0.7561261057853699, 0.7100270986557007]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_test_f, y_test_f = filter_lengths(X_test, y_test, min_length=1, max_length=200)\n",
+    "\n",
+    "filtered_test_data = tf.data.Dataset.from_tensor_slices((X_test_f, y_test_f)).map(lambda x,y: ((x, counts_aa(x)), y))\n",
+    "filtered_test_data = filtered_test_data.batch(config.batch_size)\n",
+    "model.evaluate(filtered_test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0431419a",
+   "metadata": {},
+   "source": [
+    "## Length filter 1 - 50"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "2793fba1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2/2 [==============================] - 0s 12ms/step - loss: 0.2229 - auc_1: 0.9524 - binary_accuracy: 0.9130\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[0.22285817563533783, 0.9523809552192688, 0.9130434989929199]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_test_f, y_test_f = filter_lengths(X_test, y_test, min_length=1, max_length=50)\n",
+    "\n",
+    "filtered_test_data = tf.data.Dataset.from_tensor_slices((X_test_f, y_test_f)).map(lambda x,y: ((x, counts_aa(x)), y))\n",
+    "filtered_test_data = filtered_test_data.batch(config.batch_size)\n",
+    "model.evaluate(filtered_test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "391c8029",
+   "metadata": {},
+   "source": [
+    "## Length filter 50 - 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "775aaec1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "17/17 [==============================] - 0s 20ms/step - loss: 0.5422 - auc_1: 0.7949 - binary_accuracy: 0.7243\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[0.5421819090843201, 0.7949349880218506, 0.7242646813392639]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_test_f, y_test_f = filter_lengths(X_test, y_test, min_length=50, max_length=100)\n",
+    "\n",
+    "filtered_test_data = tf.data.Dataset.from_tensor_slices((X_test_f, y_test_f)).map(lambda x,y: ((x, counts_aa(x)), y))\n",
+    "filtered_test_data = filtered_test_data.batch(config.batch_size)\n",
+    "model.evaluate(filtered_test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f6fc1c8",
+   "metadata": {},
+   "source": [
+    "## Length filter 100 - 150"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "555b49bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "45/45 [==============================] - 1s 26ms/step - loss: 0.5798 - auc_1: 0.7549 - binary_accuracy: 0.7035\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[0.5798361897468567, 0.7549368143081665, 0.703496515750885]"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_test_f, y_test_f = filter_lengths(X_test, y_test, min_length=100, max_length=150)\n",
+    "\n",
+    "filtered_test_data = tf.data.Dataset.from_tensor_slices((X_test_f, y_test_f)).map(lambda x,y: ((x, counts_aa(x)), y))\n",
+    "filtered_test_data = filtered_test_data.batch(config.batch_size)\n",
+    "model.evaluate(filtered_test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3b4a4e1",
+   "metadata": {},
+   "source": [
+    "## Length filter 150 - 200"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "94c7bf81",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "51/51 [==============================] - 2s 33ms/step - loss: 0.6006 - auc_1: 0.7352 - binary_accuracy: 0.7022\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[0.6005921959877014, 0.7351933717727661, 0.7022332549095154]"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_test_f, y_test_f = filter_lengths(X_test, y_test, min_length=150, max_length=200)\n",
+    "\n",
+    "filtered_test_data = tf.data.Dataset.from_tensor_slices((X_test_f, y_test_f)).map(lambda x,y: ((x, counts_aa(x)), y))\n",
+    "filtered_test_data = filtered_test_data.batch(config.batch_size)\n",
+    "model.evaluate(filtered_test_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7970bf68",
+   "metadata": {},
+   "source": [
+    "## Length filter 1 - 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "9b416d7c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "19/19 [==============================] - 0s 19ms/step - loss: 0.5173 - auc_1: 0.8138 - binary_accuracy: 0.7390\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[0.5172854661941528, 0.8138336539268494, 0.7389830350875854]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_test_f, y_test_f = filter_lengths(X_test, y_test, min_length=1, max_length=100)\n",
+    "\n",
+    "filtered_test_data = tf.data.Dataset.from_tensor_slices((X_test_f, y_test_f)).map(lambda x,y: ((x, counts_aa(x)), y))\n",
+    "filtered_test_data = filtered_test_data.batch(config.batch_size)\n",
+    "model.evaluate(filtered_test_data)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "serverless"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Filtering solubility test set

| Length filter | # Test seqs |  AUC  |  ACC |
|:-------------:|:-----------:|:-----:|:----:|
|      None     |     1845    | 0.756 | 0.71 |
|      1-50     |      23     | 0.952 | 0.91 |
|     50-100    |     272     | 0.795 | 0.72 |
|    100-150    |     715     | 0.755 | 0.70 |
|    150-200    |     806     | 0.735 | 0.70 |
|     1-100     |     295     | 0.814 | 0.74 |

Length distributions of test set:

![image](https://user-images.githubusercontent.com/51170839/208029697-bde82596-f160-499b-9d12-5af8d3ba2e13.png)
